### PR TITLE
Check null since JSON.parse can't handle nulls.

### DIFF
--- a/jquery.storage.js
+++ b/jquery.storage.js
@@ -19,11 +19,20 @@
             }
         };
 
-        try {
-            $.support[method] = method in window && window[method] !== null && window[method].setItem("writeSupport", "1") && window[method].removeItem("writeSupport");
-        } catch (e) {
-            $.support[method] = false;
-        }
+        var storageSupport = function(type) {
+            try {
+                if (type in window && window[type] !== null) {
+                    window[type].setItem("jquery.storage.writeSupport", "1");
+                    window[type].removeItem("jquery.storage.writeSupport");
+                    return true;
+                }
+            }
+            catch(e) { }
+
+            return false;
+        };
+
+        $.support[method] = storageSupport(method);
 
         $[method] = function(key, value) {
             var options = $.extend({}, defaults, $[method].options);

--- a/jquery.storage.js
+++ b/jquery.storage.js
@@ -19,11 +19,11 @@
             }
         };
 
-        var storageSupport = function(type) {
+        var storageSupport = function(method) {
             try {
-                if (type in window && window[type] !== null) {
-                    window[type].setItem("jquery.storage.writeSupport", "1");
-                    window[type].removeItem("jquery.storage.writeSupport");
+                if (method in window && window[method] !== null) {
+                    window[method].setItem("jqueryStorageWriteSupport", "1");
+                    window[method].removeItem("jqueryStorageWriteSupport");
                     return true;
                 }
             }

--- a/jquery.storage.js
+++ b/jquery.storage.js
@@ -20,7 +20,7 @@
         };
 
         try {
-            $.support[method] = method in window && window[method] !== null;
+            $.support[method] = method in window && window[method] !== null && window[method].setItem("writeSupport", "1") && window[method].removeItem("writeSupport");
         } catch (e) {
             $.support[method] = false;
         }

--- a/jquery.storage.js
+++ b/jquery.storage.js
@@ -29,8 +29,9 @@
             var options = $.extend({}, defaults, $[method].options);
 
             this.getItem = function( key ) {
-                var returns = function(key){
-                    return JSON.parse($.support[method] ? window[method].getItem(key) : $.cookie(options.cookiePrefix + key));
+                var returns = function (key) {
+                    var val = $.support[method] ? window[method].getItem(key) : $.cookie(options.cookiePrefix + key);
+                    return val && JSON.parse(val);
                 };
                 if(typeof key === 'string') return returns(key);
 

--- a/jquery.storage.js
+++ b/jquery.storage.js
@@ -40,7 +40,7 @@
             this.getItem = function( key ) {
                 var returns = function (key) {
                     var val = $.support[method] ? window[method].getItem(key) : $.cookie(options.cookiePrefix + key);
-                    return val && JSON.parse(val);
+                    return val && ($.support[method] ? JSON.parse(val) : val);
                 };
                 if(typeof key === 'string') return returns(key);
 


### PR DESCRIPTION
JSON.parse can't handle null parameters.
This can cause unexpected behavior (especially in chrome for Android and IE11)
